### PR TITLE
Align glossary layout with table of contents

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -53,16 +53,22 @@
         </div>
       </div>
     </nav>
-    <main>
-      <section class="container glossary-section">
-        <div class="section-header">
-          <h2 class="section-title">Glossar &amp; Hinweise</h2>
-          <button id="glossary-toggle" class="toggle-button" aria-expanded="false" aria-controls="glossary-content">
-            Glossar anzeigen
-          </button>
+    <section class="glossary-bar">
+      <div class="container toc-bar__inner">
+        <button
+          id="glossary-toggle"
+          class="toggle-button"
+          aria-expanded="false"
+          aria-controls="glossary-panel"
+        >
+          Glossar &amp; Hinweise
+        </button>
+        <div id="glossary-panel" class="collapse-panel">
+          <div id="glossary-content" class="glossary-content"></div>
         </div>
-        <div id="glossary-content" class="glossary-content collapse-panel"></div>
-      </section>
+      </div>
+    </section>
+    <main>
       <section class="container translation-section">
         <div class="translation-header">
           <h2 class="section-title">Übersetzung</h2>

--- a/web/styles.css
+++ b/web/styles.css
@@ -167,6 +167,13 @@ body {
   box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
 }
 
+.glossary-bar {
+  background: rgba(245, 246, 250, 0.96);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.08);
+  margin-bottom: 2rem;
+}
+
 .toc-bar__inner {
   display: flex;
   flex-direction: column;
@@ -238,7 +245,6 @@ body {
 }
 
 
-.glossary-section,
 .translation-section {
   background: transparent;
 }


### PR DESCRIPTION
## Summary
- style the glossary controls to match the collapsible table of contents and remove the preview header
- rebuild the table of contents based on the active language selection and collapse it when a link is chosen
- add constants for toggle labels and align glossary collapse handling with the TOC behavior

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692cacdd0b448333af3a2aab7e65099a)